### PR TITLE
Reafactor: 회원 관련 정보 수정 및 API 생성

### DIFF
--- a/src/main/java/baeksaitong/sofp/SofpApplication.java
+++ b/src/main/java/baeksaitong/sofp/SofpApplication.java
@@ -3,9 +3,11 @@ package baeksaitong.sofp;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.cloud.openfeign.EnableFeignClients;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 
 @SpringBootApplication
 @EnableFeignClients
+@EnableJpaAuditing
 public class SofpApplication {
 
 	public static void main(String[] args) {

--- a/src/main/java/baeksaitong/sofp/domain/auth/dto/naver/NaverAgreement.java
+++ b/src/main/java/baeksaitong/sofp/domain/auth/dto/naver/NaverAgreement.java
@@ -1,0 +1,4 @@
+package baeksaitong.sofp.domain.auth.dto.naver;
+
+public record NaverAgreement(String result) {
+}

--- a/src/main/java/baeksaitong/sofp/domain/auth/dto/request/SignUpReq.java
+++ b/src/main/java/baeksaitong/sofp/domain/auth/dto/request/SignUpReq.java
@@ -1,5 +1,6 @@
 package baeksaitong.sofp.domain.auth.dto.request;
 
+import baeksaitong.sofp.global.common.entity.enums.MemberGender;
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
@@ -28,9 +29,9 @@ public class SignUpReq {
     @Schema(description = "아이디(이메일)", example = "example@example.com")
     private String email;
 
-    @NotBlank
+    @NotNull
     @Schema(description = "성별")
-    private String gender;
+    private MemberGender gender;
 
     @NotBlank
     @Schema(description = "비밀번호")

--- a/src/main/java/baeksaitong/sofp/domain/auth/feign/NaverFeignClient.java
+++ b/src/main/java/baeksaitong/sofp/domain/auth/feign/NaverFeignClient.java
@@ -1,5 +1,6 @@
 package baeksaitong.sofp.domain.auth.feign;
 
+import baeksaitong.sofp.domain.auth.dto.naver.NaverAgreement;
 import baeksaitong.sofp.domain.auth.dto.naver.NaverProfile;
 import baeksaitong.sofp.domain.auth.dto.naver.NaverToken;
 import baeksaitong.sofp.global.config.FeignConfig;
@@ -24,4 +25,8 @@ public interface NaverFeignClient {
 
     @GetMapping
     NaverProfile getProfile(URI baseUrl, @RequestHeader("Authorization") String token);
+
+    @GetMapping
+    NaverAgreement getAgreement(URI baseUrl, @RequestHeader("Authorization") String token);
+
 }

--- a/src/main/java/baeksaitong/sofp/domain/auth/service/AuthService.java
+++ b/src/main/java/baeksaitong/sofp/domain/auth/service/AuthService.java
@@ -32,13 +32,13 @@ public class AuthService {
     private final JwtTokenProvider jwtTokenProvider;
 
     public LoginRes singUp(SignUpReq req) {
-        if(memberRepository.existsByUid(req.getEmail())){
+        if(memberRepository.existsByEmail(req.getEmail())){
             throw new BusinessException(AuthErrorCode.DUPLICATIE_ID);
         }
 
         Member member = Member.builder()
                 .name(req.getName())
-                .uid(req.getEmail())
+                .email(req.getEmail())
                 .birthday(req.getBirthday())
                 .pwd(passwordEncoder.encode(req.getPassword()))
                 .gender(req.getGender())
@@ -58,13 +58,13 @@ public class AuthService {
     }
 
     public void checkId(CheckIdReq req) {
-        if(memberRepository.existsByUid(req.getEmail())){
+        if(memberRepository.existsByEmail(req.getEmail())){
             throw new BusinessException(AuthErrorCode.DUPLICATIE_ID);
         }
     }
 
     public String login(LoginReq req) {
-        Member member = memberRepository.findByUid(req.getEmail()).orElseThrow(
+        Member member = memberRepository.findByEmail(req.getEmail()).orElseThrow(
                 () -> new BusinessException(AuthErrorCode.NO_SUCH_ID)
         );
 
@@ -89,7 +89,7 @@ public class AuthService {
     ){
         boolean isNew = false;
 
-        if(!memberRepository.existsByUid(email)){
+        if(!memberRepository.existsByEmail(email)){
             singUp(SignUpReq.builder()
                     .email(email)
                     .password(id)

--- a/src/main/java/baeksaitong/sofp/domain/auth/service/AuthService.java
+++ b/src/main/java/baeksaitong/sofp/domain/auth/service/AuthService.java
@@ -85,7 +85,7 @@ public class AuthService {
     }
 
     public LoginRes oauthLogin(
-            String email, String id, LocalDate birthday, String name, MemberGender gender
+            String email, String id, LocalDate birthday, String name, MemberGender gender, Boolean agreement
     ){
         boolean isNew = false;
 
@@ -95,7 +95,7 @@ public class AuthService {
                     .password(id)
                     .birthday(birthday)
                     .name(name)
-                    .advertisement(true)
+                    .advertisement(agreement)
                     .gender(gender)
                     .build());
             isNew = true;

--- a/src/main/java/baeksaitong/sofp/domain/auth/service/AuthService.java
+++ b/src/main/java/baeksaitong/sofp/domain/auth/service/AuthService.java
@@ -7,6 +7,7 @@ import baeksaitong.sofp.domain.auth.dto.response.LoginRes;
 import baeksaitong.sofp.domain.auth.error.AuthErrorCode;
 import baeksaitong.sofp.domain.member.repository.MemberRepository;
 import baeksaitong.sofp.global.common.entity.Member;
+import baeksaitong.sofp.global.common.entity.enums.MemberGender;
 import baeksaitong.sofp.global.error.exception.BusinessException;
 import baeksaitong.sofp.global.jwt.JwtTokenProvider;
 import lombok.RequiredArgsConstructor;
@@ -84,7 +85,7 @@ public class AuthService {
     }
 
     public LoginRes oauthLogin(
-            String email, String id, LocalDate birthday, String name, String gender
+            String email, String id, LocalDate birthday, String name, MemberGender gender
     ){
         boolean isNew = false;
 

--- a/src/main/java/baeksaitong/sofp/domain/auth/service/KakaoService.java
+++ b/src/main/java/baeksaitong/sofp/domain/auth/service/KakaoService.java
@@ -37,7 +37,14 @@ public class KakaoService {
         KakaoToken kakaoToken = getToken(code);
         KakaoProfile profile = getProfile(kakaoToken.accessToken());
 
-        return authService.oauthLogin(profile.getEmail(), profile.getId().toString(), profile.getBirthday(), profile.getName(), (profile.getGender().equals("male")) ? MemberGender.MALE : MemberGender.FEMALE);
+        return authService.oauthLogin(
+                profile.getEmail(),
+                profile.getId().toString(),
+                profile.getBirthday(),
+                profile.getName(),
+                (profile.getGender().equals("male")) ? MemberGender.MALE : MemberGender.FEMALE,
+                Boolean.TRUE
+        );
     }
 
     private KakaoProfile getProfile(String token){

--- a/src/main/java/baeksaitong/sofp/domain/auth/service/KakaoService.java
+++ b/src/main/java/baeksaitong/sofp/domain/auth/service/KakaoService.java
@@ -5,6 +5,7 @@ import baeksaitong.sofp.domain.auth.dto.kakao.KakaoToken;
 import baeksaitong.sofp.domain.auth.dto.response.LoginRes;
 import baeksaitong.sofp.domain.auth.error.AuthErrorCode;
 import baeksaitong.sofp.domain.auth.feign.KakaoFeignClient;
+import baeksaitong.sofp.global.common.entity.enums.MemberGender;
 import baeksaitong.sofp.global.error.exception.BusinessException;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -36,7 +37,7 @@ public class KakaoService {
         KakaoToken kakaoToken = getToken(code);
         KakaoProfile profile = getProfile(kakaoToken.accessToken());
 
-        return authService.oauthLogin(profile.getEmail(), profile.getId().toString(), profile.getBirthday(), profile.getName(), profile.getGender());
+        return authService.oauthLogin(profile.getEmail(), profile.getId().toString(), profile.getBirthday(), profile.getName(), (profile.getGender().equals("male")) ? MemberGender.MALE : MemberGender.FEMALE);
     }
 
     private KakaoProfile getProfile(String token){

--- a/src/main/java/baeksaitong/sofp/domain/auth/service/NaverService.java
+++ b/src/main/java/baeksaitong/sofp/domain/auth/service/NaverService.java
@@ -5,6 +5,7 @@ import baeksaitong.sofp.domain.auth.dto.naver.NaverToken;
 import baeksaitong.sofp.domain.auth.dto.response.LoginRes;
 import baeksaitong.sofp.domain.auth.error.AuthErrorCode;
 import baeksaitong.sofp.domain.auth.feign.NaverFeignClient;
+import baeksaitong.sofp.global.common.entity.enums.MemberGender;
 import baeksaitong.sofp.global.error.exception.BusinessException;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -40,7 +41,7 @@ public class NaverService {
         NaverToken token = getToken(code);
         NaverProfile profile = getInfo(token.accessToken());
 
-        return authService.oauthLogin(profile.getEmail(), profile.getId(), profile.getBirthday(), profile.getName(), profile.getGender());
+        return authService.oauthLogin(profile.getEmail(), profile.getId(), profile.getBirthday(), profile.getName(), (profile.getGender().equals("M")) ? MemberGender.MALE : MemberGender.FEMALE);
 
     }
 

--- a/src/main/java/baeksaitong/sofp/domain/auth/service/NaverService.java
+++ b/src/main/java/baeksaitong/sofp/domain/auth/service/NaverService.java
@@ -1,5 +1,6 @@
 package baeksaitong.sofp.domain.auth.service;
 
+import baeksaitong.sofp.domain.auth.dto.naver.NaverAgreement;
 import baeksaitong.sofp.domain.auth.dto.naver.NaverProfile;
 import baeksaitong.sofp.domain.auth.dto.naver.NaverToken;
 import baeksaitong.sofp.domain.auth.dto.response.LoginRes;
@@ -7,6 +8,7 @@ import baeksaitong.sofp.domain.auth.error.AuthErrorCode;
 import baeksaitong.sofp.domain.auth.feign.NaverFeignClient;
 import baeksaitong.sofp.global.common.entity.enums.MemberGender;
 import baeksaitong.sofp.global.error.exception.BusinessException;
+import feign.FeignException;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
@@ -37,11 +39,21 @@ public class NaverService {
     @Value("${social.naver.url.profile}")
     private String profileUrl;
 
+    @Value("${social.naver.url.agreement}")
+    private String agreementUrl;
+
     public LoginRes login(String code) {
         NaverToken token = getToken(code);
         NaverProfile profile = getInfo(token.accessToken());
 
-        return authService.oauthLogin(profile.getEmail(), profile.getId(), profile.getBirthday(), profile.getName(), (profile.getGender().equals("M")) ? MemberGender.MALE : MemberGender.FEMALE);
+        return authService.oauthLogin(
+                profile.getEmail(),
+                profile.getId(),
+                profile.getBirthday(),
+                profile.getName(),
+                (profile.getGender().equals("M")) ? MemberGender.MALE : MemberGender.FEMALE,
+                getAgreement(token.accessToken())
+        );
 
     }
 
@@ -58,6 +70,19 @@ public class NaverService {
         try {
             return naverFeignClient.getProfile(new URI(profileUrl), "Bearer " + token);
         } catch (Exception e) {
+            log.error("error while getting naver user profile: ", e);
+            throw new BusinessException(AuthErrorCode.NAVER_ERROR);
+        }
+    }
+
+    private Boolean getAgreement(String token){
+        try {
+            NaverAgreement agreement = naverFeignClient.getAgreement(new URI(agreementUrl), "Bearer " + token);
+            return (agreement.result() != null && agreement.result().equals("success"));
+        } catch (FeignException.NotFound e){
+            return false;
+        }
+        catch (Exception e) {
             log.error("error while getting naver user profile: ", e);
             throw new BusinessException(AuthErrorCode.NAVER_ERROR);
         }

--- a/src/main/java/baeksaitong/sofp/domain/member/controller/MemberController.java
+++ b/src/main/java/baeksaitong/sofp/domain/member/controller/MemberController.java
@@ -1,10 +1,7 @@
 package baeksaitong.sofp.domain.member.controller;
 
-import baeksaitong.sofp.domain.auth.dto.response.BasicInfoRes;
+import baeksaitong.sofp.domain.member.dto.response.*;
 import baeksaitong.sofp.domain.member.dto.request.*;
-import baeksaitong.sofp.domain.member.dto.response.AllergyRes;
-import baeksaitong.sofp.domain.member.dto.response.DiseaseRes;
-import baeksaitong.sofp.domain.member.dto.response.PillRes;
 import baeksaitong.sofp.domain.member.service.MemberService;
 import baeksaitong.sofp.domain.search.dto.response.KeywordRes;
 import baeksaitong.sofp.global.common.dto.BaseResponse;
@@ -50,6 +47,16 @@ public class MemberController {
         return BaseResponse.ok(res);
     }
 
+
+    @Operation(tags = "3. Member", summary = "회원 상세 정보 제공", description = "회원 상세 정보를 제공합니다.")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "닉네임 및 프로필 사진 주소 제공")
+    })
+    @PostMapping("/info/detail")
+    public ResponseEntity<DetailInfoRes> getDetailInfo(@AuthenticationPrincipal Member member){
+        DetailInfoRes res = memberService.getDetailInfo(member);
+        return BaseResponse.ok(res);
+    }
 
     @Operation(tags = "3. Member", summary = "프로필 사진 등록", description = "프로필 사진을 등록합니다.")
     @ApiResponses({

--- a/src/main/java/baeksaitong/sofp/domain/member/controller/MemberController.java
+++ b/src/main/java/baeksaitong/sofp/domain/member/controller/MemberController.java
@@ -27,6 +27,18 @@ public class MemberController {
 
     private final MemberService memberService;
 
+    @Operation(tags = "3. Member", summary = "회원 정보 수정 전 비밀번호 인증", description = "회원 수정을 위해 상세정보 페이지로 가기전에 비밀번호로 회원을 인증합니다.")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "인증에 성공했습니다"),
+            @ApiResponse(responseCode = "404", description = "code: A-002 | message: 비밀번호가 일치하지 않습니다.",
+                    content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
+    })
+    @PostMapping("/verification")
+    public ResponseEntity<String> verification(@ModelAttribute VerificationReq req, @AuthenticationPrincipal Member member){
+        memberService.verification(req.getPassword(),member);
+        return BaseResponse.ok("인증에 성공했습니다");
+    }
+
     @Operation(tags = "3. Member", summary = "프로필 사진 등록", description = "프로필 사진을 등록합니다.")
     @ApiResponses({
             @ApiResponse(responseCode = "200", description = "프로필 사진을 등록에 성공했습니다"),

--- a/src/main/java/baeksaitong/sofp/domain/member/controller/MemberController.java
+++ b/src/main/java/baeksaitong/sofp/domain/member/controller/MemberController.java
@@ -1,5 +1,6 @@
 package baeksaitong.sofp.domain.member.controller;
 
+import baeksaitong.sofp.domain.auth.dto.response.BasicInfoRes;
 import baeksaitong.sofp.domain.member.dto.request.*;
 import baeksaitong.sofp.domain.member.dto.response.AllergyRes;
 import baeksaitong.sofp.domain.member.dto.response.DiseaseRes;
@@ -38,6 +39,17 @@ public class MemberController {
         memberService.verification(req.getPassword(),member);
         return BaseResponse.ok("인증에 성공했습니다");
     }
+
+    @Operation(tags = "3. Member", summary = "회원 기본 정보 제공", description = "회원 기본 정보를 제공합니다.")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "닉네임 및 프로필 사진 주소 제공")
+    })
+    @PostMapping("/info/basic")
+    public ResponseEntity<BasicInfoRes> getBasicInfo(@AuthenticationPrincipal Member member){
+        BasicInfoRes res = memberService.getBasicInfo(member);
+        return BaseResponse.ok(res);
+    }
+
 
     @Operation(tags = "3. Member", summary = "프로필 사진 등록", description = "프로필 사진을 등록합니다.")
     @ApiResponses({

--- a/src/main/java/baeksaitong/sofp/domain/member/dto/request/MemberEditReq.java
+++ b/src/main/java/baeksaitong/sofp/domain/member/dto/request/MemberEditReq.java
@@ -1,5 +1,6 @@
 package baeksaitong.sofp.domain.member.dto.request;
 
+import baeksaitong.sofp.global.common.entity.enums.MemberGender;
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
@@ -20,9 +21,9 @@ public class MemberEditReq {
     @Schema(description = "생일")
     private LocalDate birthday;
 
-    @NotBlank
+    @NotNull
     @Schema(description = "성별")
-    private String gender;
+    private MemberGender gender;
 
     @NotBlank
     @Schema(description = "비밀번호")

--- a/src/main/java/baeksaitong/sofp/domain/member/dto/request/MemberEditReq.java
+++ b/src/main/java/baeksaitong/sofp/domain/member/dto/request/MemberEditReq.java
@@ -25,7 +25,6 @@ public class MemberEditReq {
     @Schema(description = "성별")
     private MemberGender gender;
 
-    @NotBlank
     @Schema(description = "비밀번호")
     private String password;
 

--- a/src/main/java/baeksaitong/sofp/domain/member/dto/request/VerificationReq.java
+++ b/src/main/java/baeksaitong/sofp/domain/member/dto/request/VerificationReq.java
@@ -1,0 +1,15 @@
+package baeksaitong.sofp.domain.member.dto.request;
+
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class VerificationReq {
+    @Schema(description = "비밀번호")
+    private String password;
+}

--- a/src/main/java/baeksaitong/sofp/domain/member/dto/response/BasicInfoRes.java
+++ b/src/main/java/baeksaitong/sofp/domain/member/dto/response/BasicInfoRes.java
@@ -1,0 +1,10 @@
+package baeksaitong.sofp.domain.member.dto.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+public record BasicInfoRes(
+        @Schema(description = "닉네임")
+        String nickName,
+        @Schema(description = "프로필 사진 주소")
+        String imgUrl) {
+}

--- a/src/main/java/baeksaitong/sofp/domain/member/dto/response/DetailInfoRes.java
+++ b/src/main/java/baeksaitong/sofp/domain/member/dto/response/DetailInfoRes.java
@@ -1,0 +1,25 @@
+package baeksaitong.sofp.domain.member.dto.response;
+
+import baeksaitong.sofp.global.common.entity.enums.MemberGender;
+import io.swagger.v3.oas.annotations.media.Schema;
+
+import java.time.LocalDate;
+
+public record DetailInfoRes(
+        @Schema(description = "이름")
+        String name,
+        @Schema(description = "생일")
+        LocalDate birthday,
+        @Schema(description = "이메일")
+        String email,
+        @Schema(description = "닉네임")
+        String nickname,
+        @Schema(description = "프로필 사진 주소")
+        String imgUrl,
+        @Schema(description = "성별")
+        MemberGender gender,
+        @Schema(description = "광고 동의 여부")
+        Boolean advertisement
+
+) {
+}

--- a/src/main/java/baeksaitong/sofp/domain/member/repository/MemberRepository.java
+++ b/src/main/java/baeksaitong/sofp/domain/member/repository/MemberRepository.java
@@ -8,6 +8,6 @@ import java.util.Optional;
 
 @Repository
 public interface MemberRepository extends JpaRepository<Member, Long> {
-    Optional<Member> findByUid(String uid);
-    Boolean existsByUid(String uid);
+    Optional<Member> findByEmail(String email);
+    Boolean existsByEmail(String email);
 }

--- a/src/main/java/baeksaitong/sofp/domain/member/service/MemberService.java
+++ b/src/main/java/baeksaitong/sofp/domain/member/service/MemberService.java
@@ -10,6 +10,7 @@ import baeksaitong.sofp.domain.health.repository.DiseaseRepository;
 import baeksaitong.sofp.domain.health.repository.PillRepository;
 import baeksaitong.sofp.domain.history.service.HistoryService;
 import baeksaitong.sofp.domain.member.dto.request.MemberEditReq;
+import baeksaitong.sofp.domain.member.dto.response.DetailInfoRes;
 import baeksaitong.sofp.domain.member.dto.response.PillInfoRes;
 import baeksaitong.sofp.domain.member.dto.response.PillRes;
 import baeksaitong.sofp.domain.member.repository.MemberAllergyRepository;
@@ -244,5 +245,17 @@ public class MemberService {
 
     public BasicInfoRes getBasicInfo(Member member) {
         return new BasicInfoRes(member.getNickname(), member.getImgUrl());
+    }
+
+    public DetailInfoRes getDetailInfo(Member member) {
+        return new DetailInfoRes(
+                member.getName(),
+                member.getBirthday(),
+                member.getEmail(),
+                member.getNickname(),
+                member.getImgUrl(),
+                member.getGender(),
+                member.getAdvertisement()
+        );
     }
 }

--- a/src/main/java/baeksaitong/sofp/domain/member/service/MemberService.java
+++ b/src/main/java/baeksaitong/sofp/domain/member/service/MemberService.java
@@ -1,5 +1,6 @@
 package baeksaitong.sofp.domain.member.service;
 
+import baeksaitong.sofp.domain.auth.dto.response.BasicInfoRes;
 import baeksaitong.sofp.domain.auth.error.AuthErrorCode;
 import baeksaitong.sofp.domain.health.error.AllergyErrorCode;
 import baeksaitong.sofp.domain.health.error.DiseaseErrorCode;
@@ -239,5 +240,9 @@ public class MemberService {
         if(!passwordEncoder.matches(password, member.getPassword())){
             throw new BusinessException(AuthErrorCode.WRONG_PASSWORD);
         }
+    }
+
+    public BasicInfoRes getBasicInfo(Member member) {
+        return new BasicInfoRes(member.getNickname(), member.getImgUrl());
     }
 }

--- a/src/main/java/baeksaitong/sofp/domain/member/service/MemberService.java
+++ b/src/main/java/baeksaitong/sofp/domain/member/service/MemberService.java
@@ -1,6 +1,6 @@
 package baeksaitong.sofp.domain.member.service;
 
-import baeksaitong.sofp.domain.auth.dto.response.BasicInfoRes;
+import baeksaitong.sofp.domain.member.dto.response.BasicInfoRes;
 import baeksaitong.sofp.domain.auth.error.AuthErrorCode;
 import baeksaitong.sofp.domain.health.error.AllergyErrorCode;
 import baeksaitong.sofp.domain.health.error.DiseaseErrorCode;
@@ -67,7 +67,7 @@ public class MemberService {
     public void editMember(MemberEditReq req, Member member) {
         member.setNickname(req.getNickname());
         member.setGender(req.getGender());
-        member.setPwd(passwordEncoder.encode(req.getPassword()));
+        if(req.getPassword() != null) member.setPwd(passwordEncoder.encode(req.getPassword()));
         member.setBirthday(req.getBirthday());
         member.setAdvertisement(req.getAdvertisement());
 

--- a/src/main/java/baeksaitong/sofp/domain/member/service/MemberService.java
+++ b/src/main/java/baeksaitong/sofp/domain/member/service/MemberService.java
@@ -1,5 +1,6 @@
 package baeksaitong.sofp.domain.member.service;
 
+import baeksaitong.sofp.domain.auth.error.AuthErrorCode;
 import baeksaitong.sofp.domain.health.error.AllergyErrorCode;
 import baeksaitong.sofp.domain.health.error.DiseaseErrorCode;
 import baeksaitong.sofp.domain.health.error.PillErrorCode;
@@ -232,5 +233,11 @@ public class MemberService {
         historyService.deleteRecentViewPill(member.getId(), List.of(new Long[]{pillId}));
 
         return getRecentViewPill(count, member);
+    }
+
+    public void verification(String password, Member member) {
+        if(!passwordEncoder.matches(password, member.getPassword())){
+            throw new BusinessException(AuthErrorCode.WRONG_PASSWORD);
+        }
     }
 }

--- a/src/main/java/baeksaitong/sofp/global/common/entity/Member.java
+++ b/src/main/java/baeksaitong/sofp/global/common/entity/Member.java
@@ -25,7 +25,7 @@ public class Member extends BaseTimeEntity implements UserDetails {
 
     private String name;
     private LocalDate birthday;
-    private String uid;
+    private String email;
     private String pwd;
     private String nickname;
 
@@ -52,7 +52,7 @@ public class Member extends BaseTimeEntity implements UserDetails {
 
     @Override
     public String getUsername() {
-        return uid;
+        return email;
     }
 
     @Override

--- a/src/main/java/baeksaitong/sofp/global/common/entity/Member.java
+++ b/src/main/java/baeksaitong/sofp/global/common/entity/Member.java
@@ -1,5 +1,6 @@
 package baeksaitong.sofp.global.common.entity;
 
+import baeksaitong.sofp.global.common.entity.enums.MemberGender;
 import baeksaitong.sofp.global.common.entity.enums.MemberRole;
 import jakarta.persistence.*;
 import lombok.*;
@@ -33,7 +34,8 @@ public class Member extends BaseTimeEntity implements UserDetails {
 
     private Boolean advertisement;
 
-    private String gender;
+    @Enumerated(EnumType.STRING)
+    private MemberGender gender;
 
     @Enumerated(EnumType.STRING)
     private MemberRole role;

--- a/src/main/java/baeksaitong/sofp/global/common/entity/enums/MemberGender.java
+++ b/src/main/java/baeksaitong/sofp/global/common/entity/enums/MemberGender.java
@@ -1,0 +1,12 @@
+package baeksaitong.sofp.global.common.entity.enums;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+
+public enum MemberGender {
+    MALE, FEMALE;
+
+    @JsonCreator
+    public static MemberGender from(String s) {
+        return MemberGender.valueOf(s.toUpperCase());
+    }
+}

--- a/src/main/java/baeksaitong/sofp/global/common/service/CustomMemberDetailsService.java
+++ b/src/main/java/baeksaitong/sofp/global/common/service/CustomMemberDetailsService.java
@@ -24,7 +24,7 @@ public class CustomMemberDetailsService implements UserDetailsService {
     @Override
     @Transactional
     public UserDetails loadUserByUsername(String username) throws UsernameNotFoundException {
-        return memberRepository.findByUid(username).orElseThrow(
+        return memberRepository.findByEmail(username).orElseThrow(
                 () -> new UsernameNotFoundException(username + " 사용자를 찾을 수 없습니다.")
         );
 
@@ -33,7 +33,7 @@ public class CustomMemberDetailsService implements UserDetailsService {
 
     private User createUser(Member member) {
         List<GrantedAuthority> grantedAuthorities = List.of(new SimpleGrantedAuthority(member.getRole().toString()));
-        return new User(member.getUid(),
+        return new User(member.getEmail(),
                 member.getPassword(),
                 grantedAuthorities);
     }


### PR DESCRIPTION
## 📌 작업사항
- 성별 ENUM 통일
- 회원 기본 정보 관련 API 생성
- 소셜 로그인 광고 동의 여부 추가

## 💡 비고
- 카카오 로그인 경우 비즈니스 신청 전까지 광고 동의 여부 추가 안됨

## ✅ Github 이슈
- #26 

## 📅 작업일자
- 2024.04.02

<br>
