### PR TITLE
Feat: refresh token 인증 방식 추가

### DIFF
--- a/src/main/java/baeksaitong/sofp/domain/auth/controller/AuthController.java
+++ b/src/main/java/baeksaitong/sofp/domain/auth/controller/AuthController.java
@@ -6,7 +6,6 @@ import baeksaitong.sofp.domain.auth.dto.request.RefreshTokenReq;
 import baeksaitong.sofp.domain.auth.dto.request.SignUpReq;
 import baeksaitong.sofp.domain.auth.dto.response.LoginRes;
 import baeksaitong.sofp.domain.auth.dto.response.RefreshAccessRes;
-import baeksaitong.sofp.domain.auth.dto.response.TokenRes;
 import baeksaitong.sofp.domain.auth.service.AuthService;
 import baeksaitong.sofp.global.common.dto.BaseResponse;
 import baeksaitong.sofp.global.error.dto.ErrorResponse;
@@ -74,8 +73,23 @@ public class AuthController {
     })
     @PostMapping("/refresh/access")
     public ResponseEntity<RefreshAccessRes> refreshAccess(@RequestBody RefreshTokenReq req) {
-        RefreshAccessRes res = authService.refershAccessToken(req);
+        RefreshAccessRes res = authService.refreshAccessToken(req);
         return BaseResponse.ok(res);
+    }
+
+    @Operation(tags = "1. Auth", summary = "토큰 만료기한 조회", description = "유효한 토큰인 경우, 해당 토큰의 만료기한을 조회할 수 있습니다.")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "토큰의 만료기한 (yyyy-MM-dd HH:mm:ss)"),
+            @ApiResponse(responseCode = "400", description = "code: J-000 | message: 유효하지 않은 jwt 토큰입니다. <br>" +
+                    "code: J-001 | message: 만료된 jwt 토큰입니다. <br>" +
+                    "code: J-002 | message: 지원하지 않는 JWT 토큰입니다.<br>" +
+                    "code: J-003 | message: 토큰이 필요합니다.",
+                    content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
+    })
+    @GetMapping("/expiration")
+    public ResponseEntity<String> getExpiration(@RequestParam String token) {
+        String expiration = authService.getExpiration(token);
+        return BaseResponse.ok(expiration);
     }
 
 }

--- a/src/main/java/baeksaitong/sofp/domain/auth/controller/AuthController.java
+++ b/src/main/java/baeksaitong/sofp/domain/auth/controller/AuthController.java
@@ -6,6 +6,7 @@ import baeksaitong.sofp.domain.auth.dto.request.RefreshTokenReq;
 import baeksaitong.sofp.domain.auth.dto.request.SignUpReq;
 import baeksaitong.sofp.domain.auth.dto.response.LoginRes;
 import baeksaitong.sofp.domain.auth.dto.response.RefreshAccessRes;
+import baeksaitong.sofp.domain.auth.dto.response.TokenRes;
 import baeksaitong.sofp.domain.auth.service.AuthService;
 import baeksaitong.sofp.global.common.dto.BaseResponse;
 import baeksaitong.sofp.global.error.dto.ErrorResponse;
@@ -63,7 +64,7 @@ public class AuthController {
 
     @Operation(tags = "1. Auth", summary = "Access Token 갱신", description = "refresh 토큰을 통해 access 토큰을 재발급합니다.")
     @ApiResponses({
-            @ApiResponse(responseCode = "200", description = "access, refresh 토큰"),
+            @ApiResponse(responseCode = "200", description = "access 토큰"),
             @ApiResponse(responseCode = "404", description = "code: J-000 | message: 유효하지 않은 jwt 토큰입니다. <br>" +
                     "code: J-001 | message: 만료된 jwt 토큰입니다. <br>" +
                     "code: J-002 | message: 지원하지 않는 JWT 토큰입니다.<br>" +
@@ -73,7 +74,23 @@ public class AuthController {
     })
     @PostMapping("/refresh/access")
     public ResponseEntity<RefreshAccessRes> refreshAccess(@RequestBody RefreshTokenReq req) {
-        RefreshAccessRes res = authService.refreshAccessToken(req);
+        RefreshAccessRes res = authService.refreshAccessToken0(req);
+        return BaseResponse.ok(res);
+    }
+
+    @Operation(tags = "1. Auth", summary = "Access 및 Refresh Token 갱신", description = "refresh 토큰을 통해 access 및 refresh 토큰을 재발급합니다.")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "access, refresh 토큰"),
+            @ApiResponse(responseCode = "404", description = "code: J-000 | message: 유효하지 않은 jwt 토큰입니다. <br>" +
+                    "code: J-001 | message: 만료된 jwt 토큰입니다. <br>" +
+                    "code: J-002 | message: 지원하지 않는 JWT 토큰입니다.<br>" +
+                    "code: J-003 | message: 토큰이 필요합니다.<br>" +
+                    "code: J-004 | message: 토큰을 갱신할 수 없습니다.",
+                    content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
+    })
+    @PostMapping("/refresh")
+    public ResponseEntity<TokenRes> refresh(@RequestBody RefreshTokenReq req) {
+        TokenRes res = authService.refresh(req);
         return BaseResponse.ok(res);
     }
 

--- a/src/main/java/baeksaitong/sofp/domain/auth/controller/AuthController.java
+++ b/src/main/java/baeksaitong/sofp/domain/auth/controller/AuthController.java
@@ -2,8 +2,11 @@ package baeksaitong.sofp.domain.auth.controller;
 
 import baeksaitong.sofp.domain.auth.dto.request.CheckIdReq;
 import baeksaitong.sofp.domain.auth.dto.request.LoginReq;
+import baeksaitong.sofp.domain.auth.dto.request.RefreshTokenReq;
 import baeksaitong.sofp.domain.auth.dto.request.SignUpReq;
 import baeksaitong.sofp.domain.auth.dto.response.LoginRes;
+import baeksaitong.sofp.domain.auth.dto.response.RefreshAccessRes;
+import baeksaitong.sofp.domain.auth.dto.response.TokenRes;
 import baeksaitong.sofp.domain.auth.service.AuthService;
 import baeksaitong.sofp.global.common.dto.BaseResponse;
 import baeksaitong.sofp.global.error.dto.ErrorResponse;
@@ -59,5 +62,20 @@ public class AuthController {
         return BaseResponse.ok(new LoginRes(false, authService.login(req)));
     }
 
+    @Operation(tags = "1. Auth", summary = "Access Token 갱신", description = "refresh 토큰을 통해 access 토큰을 재발급합니다.")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "access, refresh 토큰"),
+            @ApiResponse(responseCode = "404", description = "code: J-000 | message: 유효하지 않은 jwt 토큰입니다. <br>" +
+                    "code: J-001 | message: 만료된 jwt 토큰입니다. <br>" +
+                    "code: J-002 | message: 지원하지 않는 JWT 토큰입니다.<br>" +
+                    "code: J-003 | message: 토큰이 필요합니다.<br>" +
+                    "code: J-004 | message: 토큰을 갱신할 수 없습니다.",
+                    content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
+    })
+    @PostMapping("/refresh/access")
+    public ResponseEntity<RefreshAccessRes> refreshAccess(@RequestBody RefreshTokenReq req) {
+        RefreshAccessRes res = authService.refershAccessToken(req);
+        return BaseResponse.ok(res);
+    }
 
 }

--- a/src/main/java/baeksaitong/sofp/domain/auth/dto/request/RefreshTokenReq.java
+++ b/src/main/java/baeksaitong/sofp/domain/auth/dto/request/RefreshTokenReq.java
@@ -1,0 +1,11 @@
+package baeksaitong.sofp.domain.auth.dto.request;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
+
+public record RefreshTokenReq(
+        @Schema(description = "Refresh Token")
+        @NotBlank
+        String refreshToken
+) {
+}

--- a/src/main/java/baeksaitong/sofp/domain/auth/dto/response/LoginRes.java
+++ b/src/main/java/baeksaitong/sofp/domain/auth/dto/response/LoginRes.java
@@ -5,6 +5,8 @@ import io.swagger.v3.oas.annotations.media.Schema;
 public record LoginRes(
         @Schema(description = "신규 사용자 여부 - 해당 경우 사용자 설정 과정 수행")
         Boolean isNew,
-        @Schema(description = "로그인 토큰")
-        String token) {
+
+        @Schema(description = "access 토큰, refresh 토큰")
+        TokenRes token
+) {
 }

--- a/src/main/java/baeksaitong/sofp/domain/auth/dto/response/RefreshAccessRes.java
+++ b/src/main/java/baeksaitong/sofp/domain/auth/dto/response/RefreshAccessRes.java
@@ -1,0 +1,9 @@
+package baeksaitong.sofp.domain.auth.dto.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+public record RefreshAccessRes(
+        @Schema(description = "갱신된 Access Token")
+        String accessToken
+) {
+}

--- a/src/main/java/baeksaitong/sofp/domain/auth/dto/response/TokenRes.java
+++ b/src/main/java/baeksaitong/sofp/domain/auth/dto/response/TokenRes.java
@@ -1,0 +1,11 @@
+package baeksaitong.sofp.domain.auth.dto.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+public record TokenRes (
+        @Schema(description = "access 토큰")
+        String accessToken,
+        @Schema(description = "refresh 토큰")
+        String refreshToken
+){
+}

--- a/src/main/java/baeksaitong/sofp/domain/auth/service/AuthService.java
+++ b/src/main/java/baeksaitong/sofp/domain/auth/service/AuthService.java
@@ -115,11 +115,8 @@ public class AuthService {
                 .build()));
     }
 
-    public RefreshAccessRes refreshAccessToken(RefreshTokenReq req) {
-        String token = req.refreshToken();
-        String userId = jwtTokenProvider.getUserId(token);
-        jwtTokenProvider.validateRefreshToken(token, userId);
-        Authentication authentication = jwtTokenProvider.getAuthentication(token);
+    public RefreshAccessRes refreshAccessToken0(RefreshTokenReq req) {
+        Authentication authentication = validateRefreshTokenAndGetAuthentication(req);
         return new RefreshAccessRes(jwtTokenProvider.createAccessToken(authentication));
     }
 
@@ -129,5 +126,17 @@ public class AuthService {
         Date expiration = jwtTokenProvider.getExpiration(token);
         SimpleDateFormat dateFormat = new SimpleDateFormat("yyyy-MM-dd HH:mm:ss");
         return dateFormat.format(expiration);
+    }
+
+    public TokenRes refresh(RefreshTokenReq req) {
+        Authentication authentication = validateRefreshTokenAndGetAuthentication(req);
+        return new TokenRes(jwtTokenProvider.createAccessToken(authentication), jwtTokenProvider.createRefreshToken(authentication) );
+    }
+
+    private Authentication validateRefreshTokenAndGetAuthentication(RefreshTokenReq req) {
+        String token = req.refreshToken();
+        String userId = jwtTokenProvider.getUserId(token);
+        jwtTokenProvider.validateRefreshToken(token, userId);
+        return jwtTokenProvider.getAuthentication(token);
     }
 }

--- a/src/main/java/baeksaitong/sofp/domain/auth/service/AuthService.java
+++ b/src/main/java/baeksaitong/sofp/domain/auth/service/AuthService.java
@@ -21,7 +21,9 @@ import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.stereotype.Service;
 
+import java.text.SimpleDateFormat;
 import java.time.LocalDate;
+import java.util.Date;
 
 import static baeksaitong.sofp.global.common.entity.enums.MemberRole.ROLE_USER;
 
@@ -113,7 +115,7 @@ public class AuthService {
                 .build()));
     }
 
-    public RefreshAccessRes refershAccessToken(RefreshTokenReq req) {
+    public RefreshAccessRes refreshAccessToken(RefreshTokenReq req) {
         String token = req.refreshToken();
         String userId = jwtTokenProvider.getUserId(token);
         jwtTokenProvider.validateRefreshToken(token, userId);
@@ -122,4 +124,10 @@ public class AuthService {
     }
 
 
+    public String getExpiration(String token) {
+        jwtTokenProvider.validateToken(token);
+        Date expiration = jwtTokenProvider.getExpiration(token);
+        SimpleDateFormat dateFormat = new SimpleDateFormat("yyyy-MM-dd HH:mm:ss");
+        return dateFormat.format(expiration);
+    }
 }

--- a/src/main/java/baeksaitong/sofp/domain/auth/service/AuthService.java
+++ b/src/main/java/baeksaitong/sofp/domain/auth/service/AuthService.java
@@ -2,8 +2,10 @@ package baeksaitong.sofp.domain.auth.service;
 
 import baeksaitong.sofp.domain.auth.dto.request.CheckIdReq;
 import baeksaitong.sofp.domain.auth.dto.request.LoginReq;
+import baeksaitong.sofp.domain.auth.dto.request.RefreshTokenReq;
 import baeksaitong.sofp.domain.auth.dto.request.SignUpReq;
 import baeksaitong.sofp.domain.auth.dto.response.LoginRes;
+import baeksaitong.sofp.domain.auth.dto.response.RefreshAccessRes;
 import baeksaitong.sofp.domain.auth.dto.response.TokenRes;
 import baeksaitong.sofp.domain.auth.error.AuthErrorCode;
 import baeksaitong.sofp.domain.member.repository.MemberRepository;
@@ -110,4 +112,14 @@ public class AuthService {
                 .password(id)
                 .build()));
     }
+
+    public RefreshAccessRes refershAccessToken(RefreshTokenReq req) {
+        String token = req.refreshToken();
+        String userId = jwtTokenProvider.getUserId(token);
+        jwtTokenProvider.validateRefreshToken(token, userId);
+        Authentication authentication = jwtTokenProvider.getAuthentication(token);
+        return new RefreshAccessRes(jwtTokenProvider.createAccessToken(authentication));
+    }
+
+
 }

--- a/src/main/java/baeksaitong/sofp/domain/verification/service/VerificationService.java
+++ b/src/main/java/baeksaitong/sofp/domain/verification/service/VerificationService.java
@@ -7,10 +7,9 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 
-import java.time.Duration;
 import java.util.Random;
 
-import static baeksaitong.sofp.global.common.Constants.SING_UP_FLAG;
+import static baeksaitong.sofp.global.redis.RedisPrefix.*;
 
 @Service
 @RequiredArgsConstructor
@@ -19,28 +18,25 @@ public class VerificationService {
     private final MailService mailService;
     private final RedisService redisService;
 
-    private final int CODE_LENGTH = 6;
-
     @Value("${spring.mail.auth-code-expiration-minutes}")
-    private int CODE_MINUTE;
+    public static int SIGN_CODE_MINUTE;
 
     public void sendEmailCode(String email) {
-        String code = makeRandomNumber();
+        String code = makeRandomNumber(6);
         String title = "회원가입 인증 이메일 입니다.";
         String content =
                 "인증번호 : " +  code +
-                        "<br> 유효시간은 " + CODE_MINUTE + "분 입니다." +
+                        "<br> 유효시간은 " + SIGN_CODE_MINUTE + "분 입니다." +
                         "<br> 인증번호를 제대로 입력해주세요";
-        String key = SING_UP_FLAG + email;
 
         mailService.mailSend(email,title,content);
-        redisService.setValues(key, code, Duration.ofMinutes(CODE_MINUTE));
+        redisService.save(SING_UP, email, code, SING_UP.getDuration());
     }
 
-    private String makeRandomNumber() {
+    private String makeRandomNumber(int codeLength) {
         Random r = new Random();
         StringBuilder randomNumber = new StringBuilder();
-        for(int i = 0; i < CODE_LENGTH; i++) {
+        for(int i = 0; i < codeLength; i++) {
             randomNumber.append(r.nextInt(10));
         }
 
@@ -48,16 +44,16 @@ public class VerificationService {
     }
 
     public boolean checkEmailCode(String email, String code) {
-        String key = SING_UP_FLAG + email;
-        
-        if(!redisService.hasKey(key)){
+
+        if(redisService.hasNoKey(SING_UP, email)){
             throw new BusinessException(MailErrorCode.EXPIRED_VERIFICATION_CODE);
         }
 
-        if(!code.equals(redisService.getValues(key))){
+        if(!code.equals(redisService.get(SING_UP, email))){
             throw new BusinessException(MailErrorCode.INCORRECT_VERIFICATION_CODE);
         }
-        redisService.deleteValues(key);
+
+        redisService.delete(SING_UP, email);
 
         return true;
     }

--- a/src/main/java/baeksaitong/sofp/global/common/Constants.java
+++ b/src/main/java/baeksaitong/sofp/global/common/Constants.java
@@ -1,7 +1,6 @@
 package baeksaitong.sofp.global.common;
 
 public class Constants {
-    public static final String JWT_AUTHORITIES_KEY = "Authorization";
     public static final String OAUTH_GRANT_TYPE = "authorization_code";
     public static final String EMAIL_REGEXP = "^[0-9a-zA-Z]([-_.]?[0-9a-zA-Z])*@[0-9a-zA-Z]([-_.]?[0-9a-zA-Z])*\\.[a-zA-Z]{2,3}$";
     public static final String PHONE_NUM_REGEXP = "^01(?:0|1|[6-9])(?:\\d{3}|\\d{4})\\d{4}$";

--- a/src/main/java/baeksaitong/sofp/global/common/Constants.java
+++ b/src/main/java/baeksaitong/sofp/global/common/Constants.java
@@ -5,5 +5,4 @@ public class Constants {
     public static final String OAUTH_GRANT_TYPE = "authorization_code";
     public static final String EMAIL_REGEXP = "^[0-9a-zA-Z]([-_.]?[0-9a-zA-Z])*@[0-9a-zA-Z]([-_.]?[0-9a-zA-Z])*\\.[a-zA-Z]{2,3}$";
     public static final String PHONE_NUM_REGEXP = "^01(?:0|1|[6-9])(?:\\d{3}|\\d{4})\\d{4}$";
-    public static final String SING_UP_FLAG = "SING_UP";
 }

--- a/src/main/java/baeksaitong/sofp/global/jwt/JwtAuthenticationFilter.java
+++ b/src/main/java/baeksaitong/sofp/global/jwt/JwtAuthenticationFilter.java
@@ -23,7 +23,7 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
     protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain) throws ServletException, IOException {
         String token = jwtTokenProvider.resolveAccessToken(request);
 
-        if (token != null && jwtTokenProvider.validateAccessToken(token)) {
+        if (token != null && jwtTokenProvider.validateToken(token)) {
             Authentication authentication = jwtTokenProvider.getAuthentication(token);
             SecurityContextHolder.getContext().setAuthentication(authentication);
         }

--- a/src/main/java/baeksaitong/sofp/global/jwt/JwtConstants.java
+++ b/src/main/java/baeksaitong/sofp/global/jwt/JwtConstants.java
@@ -1,0 +1,16 @@
+package baeksaitong.sofp.global.jwt;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public enum JwtConstants {
+    AUTHORITIES_KEY("Authorization"),
+    TOKEN_TYPE("token_type"),
+    ACCESS_TOKEN_TYPE("access"),
+    REFRESH_TOKEN_TYPE("refresh");
+
+    final String value;
+
+}

--- a/src/main/java/baeksaitong/sofp/global/jwt/JwtTokenProvider.java
+++ b/src/main/java/baeksaitong/sofp/global/jwt/JwtTokenProvider.java
@@ -3,6 +3,7 @@ package baeksaitong.sofp.global.jwt;
 import baeksaitong.sofp.global.common.service.CustomMemberDetailsService;
 import baeksaitong.sofp.global.jwt.error.CustomJwtException;
 import baeksaitong.sofp.global.jwt.error.code.JwtErrorCode;
+import baeksaitong.sofp.global.redis.RedisService;
 import io.jsonwebtoken.*;
 import io.jsonwebtoken.security.SecurityException;
 import jakarta.annotation.PostConstruct;
@@ -21,7 +22,8 @@ import java.util.Base64;
 import java.util.Date;
 import java.util.stream.Collectors;
 
-import static baeksaitong.sofp.global.common.Constants.*;
+import static baeksaitong.sofp.global.jwt.JwtConstants.*;
+import static baeksaitong.sofp.global.redis.RedisPrefix.*;
 
 @RequiredArgsConstructor
 @Component
@@ -32,9 +34,12 @@ public class JwtTokenProvider {
     private String secretKey;
     @Value("${jwt.access-token-valid-minute}")
     private long accessTokenValidTime;
+    @Value("${jwt.refresh-token-valid-month}")
+    private long refreshTokenValidTime;
     private SecretKeySpec secretKeySpec;
 
     private final CustomMemberDetailsService memberDetailsService;
+    private final RedisService redisService;
 
     @PostConstruct
     protected void init() {
@@ -42,23 +47,41 @@ public class JwtTokenProvider {
         this.secretKeySpec = new SecretKeySpec(keyBytes, SignatureAlgorithm.HS256.getJcaName());
 
         accessTokenValidTime = accessTokenValidTime * 60 * 1000L;
+        refreshTokenValidTime = refreshTokenValidTime * 30 * 24 * 60 * 60 * 1000L;
     }
 
     public String createAccessToken(Authentication authentication) {
-        String authorities = authentication.getAuthorities().stream()
-                .map(GrantedAuthority::getAuthority)
-                .collect(Collectors.joining(","));
+        return createJwtToken(authentication, accessTokenValidTime, ACCESS_TOKEN_TYPE.getValue());
+    }
+
+    public String createRefreshToken(Authentication authentication) {
+        String token = createJwtToken(authentication, accessTokenValidTime, REFRESH_TOKEN_TYPE.getValue());
+
+        redisService.save(REFRESH_TOKEN, authentication.getName(), token, REFRESH_TOKEN.getDuration());
+        return token;
+
+    }
+
+    private String createJwtToken(Authentication authentication, Long validityTime, String tokenType) {
+        String authorities = createAuthorities(authentication);
 
         Date now = new Date();
-        Date validity = new Date(now.getTime() + this.accessTokenValidTime);
+        Date validity = new Date(now.getTime() + validityTime);
 
         return Jwts.builder()
                 .setSubject(authentication.getName())
-                .claim(JWT_AUTHORITIES_KEY, authorities)
+                .claim(TOKEN_TYPE.getValue(), tokenType)
+                .claim(AUTHORITIES_KEY.getValue(), authorities)
                 .setIssuedAt(now)
                 .setExpiration(validity)
                 .signWith(secretKeySpec, SignatureAlgorithm.HS256)
                 .compact();
+    }
+
+    private String createAuthorities(Authentication authentication) {
+        return authentication.getAuthorities().stream()
+                .map(GrantedAuthority::getAuthority)
+                .collect(Collectors.joining(","));
     }
 
     public Authentication getAuthentication(String token) {
@@ -84,7 +107,31 @@ public class JwtTokenProvider {
         return authorization.substring("Bearer ".length());
     }
 
-    public boolean validateAccessToken(String jwtToken) {
+    public void validateRefreshToken(String refreshToken, String userId) {
+        validateToken(refreshToken);
+
+        Jws<Claims> claims = Jwts.parserBuilder()
+                .setSigningKey(secretKeySpec)  // Update to use parserBuilder()
+                .build()
+                .parseClaimsJws(refreshToken);
+        String tokenType = claims.getBody().get(TOKEN_TYPE.getValue(), String.class);
+
+        if(!tokenType.equals(REFRESH_TOKEN_TYPE.getValue())){
+            throw new CustomJwtException(JwtErrorCode.INVALID_REFRESH);
+        }
+
+        if (redisService.hasNoKey(REFRESH_TOKEN, userId)) {
+            throw new CustomJwtException(JwtErrorCode.CANNOT_REFRESH);
+        }
+
+        String redisToken = redisService.get(REFRESH_TOKEN, userId);
+
+        if (!redisToken.equals(refreshToken)) {
+            throw new CustomJwtException(JwtErrorCode.INVALID_JWT_TOKEN);
+        }
+    }
+
+    public boolean validateToken(String jwtToken) {
         if (jwtToken == null) {
             throw new CustomJwtException(JwtErrorCode.EMPTY_TOKEN);
         }
@@ -94,8 +141,9 @@ public class JwtTokenProvider {
                     .setSigningKey(secretKeySpec)  // Update to use parserBuilder()
                     .build()
                     .parseClaimsJws(jwtToken);
+            Claims claimsBody = claims.getBody();
 
-            return !claims.getBody().getExpiration().before(new Date());
+            return !claimsBody.getExpiration().before(new Date()) && claimsBody.get(TOKEN_TYPE.getValue(), String.class).equals(ACCESS_TOKEN_TYPE.getValue());
         } catch (SecurityException | MalformedJwtException e) {
             log.info("JWT 토큰이 유효하지 않습니다.");
             throw new CustomJwtException(JwtErrorCode.INVALID_JWT_TOKEN);

--- a/src/main/java/baeksaitong/sofp/global/jwt/JwtTokenProvider.java
+++ b/src/main/java/baeksaitong/sofp/global/jwt/JwtTokenProvider.java
@@ -99,6 +99,15 @@ public class JwtTokenProvider {
                 .getSubject();
     }
 
+    public Date getExpiration(String jwtToken) {
+        Jws<Claims> claims = Jwts.parserBuilder()
+                .setSigningKey(secretKeySpec)
+                .build()
+                .parseClaimsJws(jwtToken);
+
+        return claims.getBody().getExpiration();
+    }
+
     public String resolveAccessToken(HttpServletRequest request) {
         String authorization = request.getHeader("Authorization");
         if (authorization == null) {

--- a/src/main/java/baeksaitong/sofp/global/jwt/JwtTokenProvider.java
+++ b/src/main/java/baeksaitong/sofp/global/jwt/JwtTokenProvider.java
@@ -76,6 +76,10 @@ public class JwtTokenProvider {
     }
 
     public boolean validateAccessToken(String jwtToken) {
+        if (jwtToken == null) {
+            throw new CustomJwtException(JwtErrorCode.EMPTY_TOKEN);
+        }
+        
         try {
             Jws<Claims> claims = Jwts.parser().setSigningKey(secretKey).parseClaimsJws(jwtToken);
             return !claims.getBody().getExpiration().before(new Date());

--- a/src/main/java/baeksaitong/sofp/global/jwt/error/code/JwtErrorCode.java
+++ b/src/main/java/baeksaitong/sofp/global/jwt/error/code/JwtErrorCode.java
@@ -11,7 +11,8 @@ public enum JwtErrorCode implements ErrorCode {
 
     INVALID_JWT_TOKEN(HttpStatus.UNAUTHORIZED, "J-000", "유효하지 않은 jwt 토큰입니다."),
     EXPIRED_JWT_TOKEN(HttpStatus.UNAUTHORIZED, "J-001", "만료된 jwt 토큰입니다."),
-    UNSUPPORTED_JWT_TOKEN(HttpStatus.UNAUTHORIZED, "J-002", "지원하지 않는 JWT 토큰입니다.");
+    UNSUPPORTED_JWT_TOKEN(HttpStatus.UNAUTHORIZED, "J-002", "지원하지 않는 JWT 토큰입니다."),
+    EMPTY_TOKEN(HttpStatus.BAD_REQUEST, "J-003", "토큰이 필요합니다.");
 
     private final HttpStatus status;
     private final String code;

--- a/src/main/java/baeksaitong/sofp/global/jwt/error/code/JwtErrorCode.java
+++ b/src/main/java/baeksaitong/sofp/global/jwt/error/code/JwtErrorCode.java
@@ -9,10 +9,12 @@ import org.springframework.http.HttpStatus;
 @AllArgsConstructor
 public enum JwtErrorCode implements ErrorCode {
 
-    INVALID_JWT_TOKEN(HttpStatus.UNAUTHORIZED, "J-000", "유효하지 않은 jwt 토큰입니다."),
-    EXPIRED_JWT_TOKEN(HttpStatus.UNAUTHORIZED, "J-001", "만료된 jwt 토큰입니다."),
-    UNSUPPORTED_JWT_TOKEN(HttpStatus.UNAUTHORIZED, "J-002", "지원하지 않는 JWT 토큰입니다."),
-    EMPTY_TOKEN(HttpStatus.BAD_REQUEST, "J-003", "토큰이 필요합니다.");
+    INVALID_JWT_TOKEN(HttpStatus.BAD_REQUEST, "J-000", "유효하지 않은 jwt 토큰입니다."),
+    EXPIRED_JWT_TOKEN(HttpStatus.BAD_REQUEST, "J-001", "만료된 jwt 토큰입니다."),
+    UNSUPPORTED_JWT_TOKEN(HttpStatus.BAD_REQUEST, "J-002", "지원하지 않는 JWT 토큰입니다."),
+    EMPTY_TOKEN(HttpStatus.BAD_REQUEST, "J-003", "토큰이 필요합니다."),
+    CANNOT_REFRESH(HttpStatus.BAD_REQUEST, "J-004", "토큰을 갱신할 수 없습니다."),
+    INVALID_REFRESH(HttpStatus.BAD_REQUEST, "J-004", "refresh 토큰이 아닙니다.");
 
     private final HttpStatus status;
     private final String code;

--- a/src/main/java/baeksaitong/sofp/global/redis/RedisPrefix.java
+++ b/src/main/java/baeksaitong/sofp/global/redis/RedisPrefix.java
@@ -1,0 +1,15 @@
+package baeksaitong.sofp.global.redis;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+import java.time.Duration;
+
+@Getter
+@AllArgsConstructor
+public enum RedisPrefix {
+    REFRESH_TOKEN(Duration.ofDays(180)),
+    SING_UP(Duration.ofMinutes(10));
+
+    final Duration duration;
+}

--- a/src/main/java/baeksaitong/sofp/global/redis/RedisService.java
+++ b/src/main/java/baeksaitong/sofp/global/redis/RedisService.java
@@ -13,28 +13,59 @@ import java.time.Duration;
 @Slf4j
 public class RedisService {
 
-    private final RedisTemplate<String, String> redisTemplate;
+    private final RedisTemplate<String, Object> redisTemplate;
 
-    public void setValues(String key, String data) {
-        ValueOperations<String, String> values = redisTemplate.opsForValue();
+    public void save(String key, String data) {
+        ValueOperations<String, Object> values = redisTemplate.opsForValue();
         values.set(key, data);
     }
 
-    public void setValues(String key, String data, Duration duration) {
-        ValueOperations<String, String> values = redisTemplate.opsForValue();
+    public void save(String key, String data, Duration duration) {
+        ValueOperations<String, Object> values = redisTemplate.opsForValue();
         values.set(key, data, duration);
     }
 
-    public String getValues(String key) {
-        ValueOperations<String, String> values = redisTemplate.opsForValue();
-        return values.get(key);
+    public void save(RedisPrefix prefix, String key, String data) {
+        ValueOperations<String, Object> values = redisTemplate.opsForValue();
+        values.set(prefix.name() + key, String.valueOf(data));
     }
 
-    public void deleteValues(String key) {
+    public void save(RedisPrefix prefix, String key, String data, Duration duration) {
+        ValueOperations<String, Object> values = redisTemplate.opsForValue();
+        values.set(prefix.name() + key, data, duration);
+    }
+
+    public String get(String key) {
+        ValueOperations<String, Object> values = redisTemplate.opsForValue();
+        return (String) values.get(key);
+    }
+
+    public String get(RedisPrefix prefix, String key) {
+        ValueOperations<String, Object> values = redisTemplate.opsForValue();
+        return (String) values.get(prefix.name() + key);
+    }
+
+    public void delete(String key) {
         redisTemplate.delete(key);
+    }
+
+    public void delete(RedisPrefix prefix, String key) {
+        redisTemplate.delete(prefix.name() + key);
     }
 
     public Boolean hasKey(String key) {
         return redisTemplate.hasKey(key);
+    }
+
+    public Boolean hasKey(RedisPrefix prefix, String key) {
+        return redisTemplate.hasKey(prefix.name() + key);
+    }
+
+    public Boolean hasNoKey(String key) {
+        return !redisTemplate.hasKey(key);
+    }
+
+    public Boolean hasNoKey(RedisPrefix prefix, String key) {
+        return !redisTemplate.hasKey(prefix.name() + key);
     }
 }


### PR DESCRIPTION
## 📌 작업사항
- 기존 인증 방식인 accsee token만 존재하던 방식에서 refresh token과 access token을 동시에 사용하는 방식으로 변경

## 💡 비고
- refresh 생성 로직
- refresh validation 로직 
- 토큰 갱신 로직
- 토큰 유효기간 확인

## ✅ Github 이슈
-  #39 

## 📅 작업일자
- 2024.05.09

<br>
