### PR TITLE
Fix: 즐겨찾기 추가 API 오류

### DIFF
--- a/src/main/java/baeksaitong/sofp/domain/favorite/service/FavoriteService.java
+++ b/src/main/java/baeksaitong/sofp/domain/favorite/service/FavoriteService.java
@@ -50,7 +50,7 @@ public class FavoriteService {
                         .build()
         );
 
-        if(req.getImage() != null) {
+        if(req.getImage() != null && req.getImage().getName().isEmpty()) {
             favorite.setImgUrl(s3Service.upload(req.getImage(), favorite.getId()));
         }
 


### PR DESCRIPTION
## 📌 작업사항
- Multipart 이미지 빈칸 오류 처리

## 💡 비고
-Multipart에 빈 값 전달 시 빈 객체 넘어와서 null 처리가 안되서 오류가 발생

## ✅ Github 이슈
- #75 

## 📅 작업일자
- 2024.05.27

<br>
